### PR TITLE
Add HexViewer and fix lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Uma aplicação web desenvolvida com React que permite analisar ficheiros direta
   - Entropia (bits/byte)
 - Cálculo de hashes: SHA-1, SHA-256 e SHA-512
 - Pré-visualização do conteúdo (texto legível ou hexadecimal)
+- Visualização completa em hexadecimal (hex dump) com opção de expansão
 - Detalhes avançados para tipos como PDF, PNG, MP3
 - Gráfico de entropia por blocos
 - Comparação binária de dois ficheiros

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import FileDropZone from './components/dropzone/FileDropZone'
 import MetadataDisplay from './components/views/MetadataDisplay'
 import HashViewer from './components/views/HashViewer'
 import FileContentViewer from './components/views/FileContentViewer'
+import HexViewer from './components/extras/HexViewer'
 import AdvancedFileDetails from './components/views/AdvancedFileDetails'
 import ExportButton from './components/views/ExportButton'
 import EntropyChart from './components/extras/EntropyChart'
@@ -86,6 +87,7 @@ function App() {
                     <EntropyChart buffer={buffer} />
                     <HashViewer buffer={buffer} />
                     <FileContentViewer file={file} buffer={buffer} />
+                    <HexViewer buffer={buffer} />
                     <AdvancedFileDetails file={file} buffer={buffer} />
                     <ExportButton file={file} buffer={buffer} />
                   </details>

--- a/src/components/views/ExportButton.jsx
+++ b/src/components/views/ExportButton.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { formatBytes, formatDate } from '../../utils/formatting/formatUtils'
+import { formatBytes } from '../../utils/formatting/formatUtils'
 import { getMagicNumber, detectFileTypeByMagic } from '../../utils/analysis/magicUtils'
 import { calculateEntropy } from '../../utils/analysis/entropyUtils'
 import { exportAsBlob } from '../../utils/export/exportUtils'

--- a/src/components/views/HashViewer.jsx
+++ b/src/components/views/HashViewer.jsx
@@ -27,7 +27,7 @@ function HashViewer({ buffer }) {
         ])
         setHashes({ sha1, sha256, sha512 })
         setStatus('Hashes gerados com sucesso!')
-      } catch (err) {
+      } catch {
         setStatus('❌ Erro ao calcular hashes.')
       }
 
@@ -41,7 +41,7 @@ function HashViewer({ buffer }) {
     try {
       await navigator.clipboard.writeText(valor)
       setStatus('Hash copiado para a área de transferência!')
-    } catch (err) {
+    } catch {
       setStatus('❌ Erro ao copiar hash.')
     }
   }
@@ -51,7 +51,7 @@ function HashViewer({ buffer }) {
     try {
       await navigator.clipboard.writeText(texto)
       setStatus('Todos os hashes copiados!')
-    } catch (err) {
+    } catch {
       setStatus('❌ Erro ao copiar todos os hashes.')
     }
   }

--- a/src/utils/analysis/magicUtils.js
+++ b/src/utils/analysis/magicUtils.js
@@ -37,6 +37,7 @@ export function detectFileTypeByMagic(magic, buffer = null, file = null) {
   // 2. Heurística por conteúdo (texto legível)
   if (buffer) {
     const text = new TextDecoder().decode(buffer.slice(0, 64))
+    // eslint-disable-next-line no-control-regex
     const isAscii = /^[\x09\x0A\x0D\x20-\x7E]+$/.test(text) // inclui tabs e quebras de linha
     if (isAscii) return 'Texto ASCII'
   }


### PR DESCRIPTION
## Summary
- include HexViewer in main analysis flow
- show hex dump after preview
- document hex dump section in README
- fix ESLint warnings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e50e80d08832b83b2bda139efda48