### PR TITLE
Add configurable entropy block size

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Uma aplicação web desenvolvida com React que permite analisar ficheiros direta
 - Visualização completa em hexadecimal (hex dump) com opção de expansão
 - Detalhes avançados para tipos como PDF, PNG, MP3
 - Gráfico de entropia por blocos
+- Tamanho de bloco configurável para o gráfico de entropia
 - Comparação binária de dois ficheiros
 - Exportação dos dados analisados em formato JSON ou TXT
 - Suporte a múltiplos ficheiros
@@ -77,6 +78,14 @@ Todos os ficheiros são lidos apenas no navegador. Nenhuma informação é envia
 │   │       └── exportUtils.js
 -------------------------------------------------------
 
+
+## Exemplo de Utilização
+
+```jsx
+<EntropyChart buffer={arrayBuffer} blockSize={512} />
+```
+
+Define o tamanho de cada bloco lido ao calcular a entropia.
 
 ## Licença
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ function App() {
   const [files, setFiles] = useState([])
   const [viewMode, setViewMode] = useState('analisar')
   const [expandedAll, setExpandedAll] = useState(true)
+  const [blockSize, setBlockSize] = useState(256)
 
   const handleFilesLoaded = (fileDataList) => {
     setFiles(fileDataList)
@@ -68,12 +69,25 @@ function App() {
             {files.length > 0 && (
               <div className="results">
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <button className="clear-button" onClick={handleClearFiles}>
-                    Limpar Ficheiros
-                  </button>
-                  <button onClick={toggleAll}>
-                    {expandedAll ? 'Recolher Todos' : 'Expandir Todos'}
-                  </button>
+                  <div>
+                    <button className="clear-button" onClick={handleClearFiles}>
+                      Limpar Ficheiros
+                    </button>
+                    <button onClick={toggleAll} style={{ marginLeft: '0.5rem' }}>
+                      {expandedAll ? 'Recolher Todos' : 'Expandir Todos'}
+                    </button>
+                  </div>
+                  <div>
+                    <label htmlFor="block-size-input" style={{ marginRight: '0.25rem' }}>Tamanho do bloco:</label>
+                    <input
+                      id="block-size-input"
+                      type="number"
+                      min="1"
+                      value={blockSize}
+                      onChange={(e) => setBlockSize(parseInt(e.target.value, 10) || 1)}
+                      style={{ width: '5rem' }}
+                    />
+                  </div>
                 </div>
 
                 {files.map(({ file, buffer }, index) => (
@@ -84,7 +98,7 @@ function App() {
                   >
                     <summary><h2>{file.name}</h2></summary>
                     <MetadataDisplay file={file} buffer={buffer} />
-                    <EntropyChart buffer={buffer} />
+                    <EntropyChart buffer={buffer} blockSize={blockSize} />
                     <HashViewer buffer={buffer} />
                     <FileContentViewer file={file} buffer={buffer} />
                     <HexViewer buffer={buffer} />

--- a/src/components/extras/EntropyChart.jsx
+++ b/src/components/extras/EntropyChart.jsx
@@ -17,13 +17,13 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
 /**
  * Componente que gera um gráfico de barras com os níveis de entropia por bloco do ficheiro.
  *
- * @param {{ buffer: ArrayBuffer, show?: boolean }} props
+ * @param {{ buffer: ArrayBuffer, blockSize?: number, show?: boolean }} props
  * @returns {JSX.Element|null}
  */
-function EntropyChart({ buffer, show = true }) {
+function EntropyChart({ buffer, blockSize = 256, show = true }) {
   if (!buffer || !show) return null
 
-  const entropies = calculateBlockEntropy(buffer, 256)
+  const entropies = calculateBlockEntropy(buffer, blockSize)
   if (!entropies || entropies.length === 0) return null
 
   const data = {


### PR DESCRIPTION
## Summary
- add `blockSize` prop to `EntropyChart`
- allow users to set entropy block size in the UI
- pass the selected block size through App component
- document configurable block size in README with example

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e595b8960832b8b89d7b9a8cb9814