### PR TITLE
Add mime-types for better MIME inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Uma aplicação web desenvolvida com React que permite analisar ficheiros direta
 - Análise local de ficheiros (sem envio para servidores)
 - Leitura de metadados:
   - Nome do ficheiro
-  - Tipo MIME
+  - Tipo MIME (mapeado com a biblioteca `mime-types`)
   - Assinatura mágica (magic number)
   - Tamanho
   - Data da última modificação
@@ -29,6 +29,7 @@ Uma aplicação web desenvolvida com React que permite analisar ficheiros direta
 - React 19
 - Vite
 - Chart.js
+- mime-types
 - JavaScript moderno (ES Modules)
 - CSS modular (App.css, theme.css, layout.css)
 - Processamento local com APIs Web (FileReader, ArrayBuffer, TextDecoder)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chart.js": "^4.4.8",
+        "mime-types": "^3.0.1",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0"
@@ -2268,6 +2269,27 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "chart.js": "^4.4.8",
+    "mime-types": "^3.0.1",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0"

--- a/src/components/views/MetadataDisplay.jsx
+++ b/src/components/views/MetadataDisplay.jsx
@@ -5,6 +5,7 @@ import { getMagicNumber, detectFileTypeByMagic } from '../../utils/analysis/magi
 import { calculateEntropy } from '../../utils/analysis/entropyUtils'
 import { fileTypeDatabase } from '../../components/data/fileTypeDatabase'
 import { fileSignatures } from '../../components/data/fileSignatures'
+import { lookup as lookupMime } from 'mime-types'
 
 /**
  * Devolve um tipo MIME com base na extensão do nome do ficheiro.
@@ -12,20 +13,8 @@ import { fileSignatures } from '../../components/data/fileSignatures'
  * @returns {string|null}
  */
 function inferMimeFromExtension(filename) {
-  const ext = filename.split('.').pop().toLowerCase()
-  const mapping = {
-    txt: 'text/plain',
-    json: 'application/json',
-    html: 'text/html',
-    jpg: 'image/jpeg',
-    jpeg: 'image/jpeg',
-    png: 'image/png',
-    pdf: 'application/pdf',
-    csv: 'text/csv',
-    xml: 'application/xml',
-    js: 'application/javascript'
-  }
-  return mapping[ext] || null
+  const result = lookupMime(filename)
+  return result || null
 }
 
 /**


### PR DESCRIPTION
## Summary
- install `mime-types` and update dependencies
- use `mime-types` lookup for extension inference
- document the new dependency and functionality

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e5960ed80832ba6eb78a62f9bffc1